### PR TITLE
Update ccsTexture.py

### DIFF
--- a/ccs_lib/ccsTexture.py
+++ b/ccs_lib/ccsTexture.py
@@ -59,6 +59,13 @@ class ccsTexture(BrStruct):
             self.textureDataSize = br.read_uint32()
             self.textureData = br.read_uint8(self.textureDataSize << 2)
 
+            #Skip mip levels
+            for i in range(self.mipmapsCount):
+                
+                br.read_uint32()
+                mipSize = br.read_uint32() << 2
+                br.seek(mipSize, Whence.CUR)
+
     
     def convertTexture(self, rawPixels = False):
         if self.btx:


### PR DESCRIPTION
Skip mip levels in texture types indexed4 and indexed8

Fixes ELX1.ccs mentioned in dothack network discord, but needs to be tested against files from other games as I only have the ones from the .hack series.