### PR TITLE
Fixes for exporting models

### DIFF
--- a/ccs_lib/Anms.py
+++ b/ccs_lib/Anms.py
@@ -194,22 +194,13 @@ class objectController(BrStruct):
         self.opacity = readFloat(br, self.opacity, self.ctrlFlags >> 9, currentFrame)
 
     def __br_write__(self, br: BinaryReader, currentFrame):
-            br.write_uint32(self.objectIndex)
-            br.write_uint32(self.ctrlFlags)
-            writeVector(br, self.positions, self.ctrlFlags, currentFrame)
-            writeRotationEuler(br, self.rotationsEuler, self.ctrlFlags >> 3, currentFrame)
-            writeRotationQuat(br, self.rotationsQuat, self.ctrlFlags >> 3, currentFrame)
-            writeVector(br, self.scales, self.ctrlFlags >> 6, currentFrame)
-            writeFloat(br, self.opacity, self.ctrlFlags >> 9, currentFrame)
-
-    def __br_write__(self, br: BinaryReader, currentFrame):
-            br.write_uint32(self.objectIndex)
-            br.write_uint32(self.ctrlFlags)
-            writeVector(br, self.positions, self.ctrlFlags, currentFrame)
-            writeRotationEuler(br, self.rotationsEuler, self.ctrlFlags >> 3, currentFrame)
-            writeRotationQuat(br, self.rotationsQuat, self.ctrlFlags >> 3, currentFrame)
-            writeVector(br, self.scales, self.ctrlFlags >> 6, currentFrame)
-            writeFloat(br, self.opacity, self.ctrlFlags >> 9, currentFrame)
+        br.write_uint32(self.objectIndex)
+        br.write_uint32(self.ctrlFlags)
+        writeVector(br, self.positions, self.ctrlFlags, currentFrame)
+        writeRotationEuler(br, self.rotationsEuler, self.ctrlFlags >> 3, currentFrame)
+        writeRotationQuat(br, self.rotationsQuat, self.ctrlFlags >> 3, currentFrame)
+        writeVector(br, self.scales, self.ctrlFlags >> 6, currentFrame)
+        writeFloat(br, self.opacity, self.ctrlFlags >> 9, currentFrame)
 
     def finalize(self, chunks):
         self.object = chunks[self.objectIndex]
@@ -252,20 +243,12 @@ class materialController(BrStruct):
         self.scaleY = readFloat(br, self.scaleY, self.ctrlFlags >> 9, currentFrame)
 
     def __br_write__(self, br: BinaryReader, currentFrame):
-            br.write_uint32(self.index)
-            br.write_uint32(self.ctrlFlags)
-            writeFloat(br, self.offsetX, self.ctrlFlags, currentFrame)
-            writeFloat(br, self.offsetY, self.ctrlFlags >> 3, currentFrame)
-            writeFloat(br, self.scaleX, self.ctrlFlags >> 6, currentFrame)
-            writeFloat(br, self.scaleY, self.ctrlFlags >> 9, currentFrame)
-
-    def __br_write__(self, br: BinaryReader, currentFrame):
-            br.write_uint32(self.index)
-            br.write_uint32(self.ctrlFlags)
-            writeFloat(br, self.offsetX, self.ctrlFlags, currentFrame)
-            writeFloat(br, self.offsetY, self.ctrlFlags >> 3, currentFrame)
-            writeFloat(br, self.scaleX, self.ctrlFlags >> 6, currentFrame)
-            writeFloat(br, self.scaleY, self.ctrlFlags >> 9, currentFrame)
+        br.write_uint32(self.index)
+        br.write_uint32(self.ctrlFlags)
+        writeFloat(br, self.offsetX, self.ctrlFlags, currentFrame)
+        writeFloat(br, self.offsetY, self.ctrlFlags >> 3, currentFrame)
+        writeFloat(br, self.scaleX, self.ctrlFlags >> 6, currentFrame)
+        writeFloat(br, self.scaleY, self.ctrlFlags >> 9, currentFrame)
 
     def finalize(self, chunks):
         self.material = chunks[self.index]

--- a/ccs_lib/ccs.py
+++ b/ccs_lib/ccs.py
@@ -21,7 +21,7 @@ from .ccsParticleGenerator import ccsParticleGenerator
 from .ccsParticleAnmCtrl import ccsParticleAnmCtrl
 from time import perf_counter
 from .Anms import *
-import gzip, zlib
+import os, gzip, zlib
 from cProfile import Profile
 
 
@@ -261,12 +261,21 @@ def readCCS(filePath):
     return ccs
 
 
-def writeCCS(filePath,  ccs: ccsFile, exportVersion= 0x120):
+def writeCCS(filePath,  ccs: ccsFile, gzipOnExport=False, exportVersion=0x120):
     time = perf_counter()
+
+    dirname, basename = os.path.split(filePath)
+    name, ext = os.path.splitext(basename)
+    exportPath = os.path.join(dirname, f"{name}_EXPORT{ext}")
+
     br = BinaryReader(encoding= "cp932")
     br.write_struct(ccs, exportVersion)
-    with open(filePath, "wb") as f:
-        f.write(br.buffer())
+    with open(exportPath, "wb") as f:
+        if gzipOnExport:
+            f.write(gzip.compress(br.buffer()))
+            print("CCS written with gzip compression")
+        else:
+            f.write(br.buffer())
 
     print(f"CCS written in {perf_counter() - time} seconds")
 

--- a/ccs_lib/ccsMaterial.py
+++ b/ccs_lib/ccsMaterial.py
@@ -79,7 +79,6 @@ class ccsMaterial(BrStruct):
         br.write_uint32(self.textureIndex)
         br.write_float32(self.alpha)
         if version > 0x130:
-            print(f'TODO: Export matertials for versions over 0x130')
             br.write_uint16(int(self.offsetX * 4096))
             br.write_uint16(int(self.offsetY * 4096))
             br.write_uint16(int(self.scaleX * 4096))


### PR DESCRIPTION
Fixes for exporting models.

Added export option:
- Export to different ccs file version or use version from file.
- Compress ccs with gzip on export.
- Remove incompatible vertex_groups from mesh's in blender, to help prevent bugged weights on export .  _This can be done from within the export window._